### PR TITLE
Fixes contributing.md hyperlink to refer to proper document link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ View the project roadmap [here](LINK_TO_PROJECT_ISSUES)
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/unexpected-lion/ourglass/blob/master/contributing.md) for contribution guidelines.
+See [CONTRIBUTING.md](https://github.com/IntriguingIguanas/IntriguingIguanas/blob/master/STYLE-GUIDE.md) for contribution guidelines.


### PR DESCRIPTION
The hyperlink in README for contributing documentation was referencing the boiler plate I pulled from.
The hyper link is fixed now to refer to our documentation