### PR TITLE
Refractor/sockets to board page

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -7,13 +7,11 @@ import BoardPage from './BoardPage.jsx'
 import SignUpPage from './SignUpPage.jsx'
 import LogInPage from './LogInPage.jsx'
 import UserProfilePage from './UserProfilePage.jsx'
-import io from 'socket.io-client'
 
 export class App extends React.Component {
 	constructor(props) {
 		super(props)
     this.state = {
-      socket: null
     }
 
     this.sendToHome = this.sendToHome.bind(this)
@@ -25,10 +23,7 @@ export class App extends React.Component {
 	}
 
   componentWillMount() {
-    var socket = io();
-    this.setState({
-      socket: socket
-    });
+
   }
 
   componentWillUnmount() {
@@ -68,18 +63,15 @@ export class App extends React.Component {
             component={ HomePage }
             sendToLogin={ this.sendToLogin }
             sendToSignup={ this.sendToSignup }
-            socket={ this.state.socket }
           />
-          <Route
-            path="/lobby"
+          <Route 
+            path="/lobby" 
             component={ Lobby }
-            socket={ this.state.socket }
           />
           <Route
             path="/lobby/:taskBoardId"
             component={ BoardPage }
             sendToLobby={ this.sendToLobby }
-            socket={ this.state.socket }
           />
           <Route
             path="/signup"
@@ -87,13 +79,12 @@ export class App extends React.Component {
           />
           <Route
             path="/login"
-            component={ LogInPage }
+            component={ LogInPage } 
           />
-          <Route
-            path="/lobby/user/:id"
+          <Route 
+            path="/lobby/user/:id" 
             component= { UserProfilePage }
-            socket={ this.state.socket }
-          />
+          /> 
         </Router>
       </div>
     )

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -23,11 +23,9 @@ export class App extends React.Component {
 	}
 
   componentWillMount() {
-
   }
 
   componentWillUnmount() {
-    this.state.socket.emit('disconnect');
   }
 
   sendToHome() {

--- a/client/src/components/BoardPage.jsx
+++ b/client/src/components/BoardPage.jsx
@@ -8,21 +8,32 @@ export class BoardPage extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      listName: ''
+      listName: '',
+      socket: null
     }
     this.onInputChange = this.onInputChange.bind(this)
     this.onCreateList = this.onCreateList.bind(this)
-    
-    var socket = this.props.route.socket
 
-    socket.on('update-board', (res) => {
-      this.props.listsFetched(res.rows)
-    })
   }
 
   componentWillMount() {
     var socket = io();
-    socket.emit('join-board', { taskBoardId: this.props.board_id })
+    this.setState({
+      socket: socket
+    }, () =>{
+      console.log('INSIDE SET STATE CALLBACK')
+      this.state.socket.emit('join-board', { taskBoardId: this.props.board_id })
+      this.state.socket.on('update-board', (res) => {
+        this.props.listsFetched(res.rows)
+      })
+    });
+  }
+
+  componentDidUpdate() {
+  }
+
+  componentWillUnmount() {
+    this.state.socket.emit('disconnect');
   }
 
   onInputChange(e) {
@@ -32,7 +43,7 @@ export class BoardPage extends React.Component {
   }
 
   onCreateList() {
-    socket.emit('create-list', { boardId: this.props.board_id, name: this.state.listName })
+    this.state.socket.emit('create-list', { boardId: this.props.board_id, name: this.state.listName })
   }
 
   render() {
@@ -45,7 +56,7 @@ export class BoardPage extends React.Component {
         { this.props.lists.map((list, index) =>
           <List
             key={ index }
-            socket = { this.props.route.socket }
+            socket = { this.state.socket }
             listname={ list.listname }
             index={ index }
           />) }

--- a/client/src/components/BoardPage.jsx
+++ b/client/src/components/BoardPage.jsx
@@ -32,7 +32,6 @@ export class BoardPage extends React.Component {
   }
 
   onCreateList() {
-    var socket = this.props.route.socket
     socket.emit('create-list', { boardId: this.props.board_id, name: this.state.listName })
   }
 

--- a/client/src/components/BoardPage.jsx
+++ b/client/src/components/BoardPage.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import List from './List.jsx'
 import { connect } from 'react-redux'
 import { createList, listsFetched } from '../actions/List.js'
+import io from 'socket.io-client'
 
 export class BoardPage extends React.Component {
   constructor(props) {
@@ -20,7 +21,7 @@ export class BoardPage extends React.Component {
   }
 
   componentWillMount() {
-    var socket = this.props.route.socket
+    var socket = io();
     socket.emit('join-board', { taskBoardId: this.props.board_id })
   }
 


### PR DESCRIPTION
Sockets was moved from App.jsx to BoardPage.jsx.
Due to async issues, setState callback had to be used to able to join a room based on the Board_ID
Able to emit to all other clients when a new list is created