### PR TITLE
Refractor/lobby router

### DIFF
--- a/client/src/components/Lobby.jsx
+++ b/client/src/components/Lobby.jsx
@@ -43,7 +43,7 @@ export class Lobby extends React.Component {
         <button onClick={ this.handleSubmit }>CREATE BOARD</button>
         { this.props.boards.map((board) => (
             <div>
-              <Link to={`/lobby/${board.board_id}`}>
+              <Link to={`/lobby/${board.id}`}>
               { board.boardname }
               </Link>
             </div>

--- a/database/db-queries/board.js
+++ b/database/db-queries/board.js
@@ -19,7 +19,7 @@ module.exports = {
   },
   //fetch board based on user_id
   fetchBoardNames:  (userId) => {
-    return db.query(`SELECT boards.boardname FROM boards INNER JOIN users_boards ON boards.id=users_boards.board_id WHERE users_boards.user_id=${userId}`)
+    return db.query(`SELECT boards.boardname, boards.id FROM boards INNER JOIN users_boards ON boards.id=users_boards.board_id WHERE users_boards.user_id=${userId}`)
   },
   //fetch board with an id
   fetchBoard: (boardId) => {


### PR DESCRIPTION
When click on a board within Lobby, you are correctly redirected to the board using the specific board id